### PR TITLE
fix: Use newer syntax for ENV variables

### DIFF
--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -153,18 +153,18 @@ module Kitchen
         def dockerfile_proxy_config
           env_variables = ""
           if config[:http_proxy]
-            env_variables << "ENV http_proxy #{config[:http_proxy]}\n"
-            env_variables << "ENV HTTP_PROXY #{config[:http_proxy]}\n"
+            env_variables << "ENV http_proxy=#{config[:http_proxy]}\n"
+            env_variables << "ENV HTTP_PROXY=#{config[:http_proxy]}\n"
           end
 
           if config[:https_proxy]
-            env_variables << "ENV https_proxy #{config[:https_proxy]}\n"
-            env_variables << "ENV HTTPS_PROXY #{config[:https_proxy]}\n"
+            env_variables << "ENV https_proxy=#{config[:https_proxy]}\n"
+            env_variables << "ENV HTTPS_PROXY=#{config[:https_proxy]}\n"
           end
 
           if config[:no_proxy]
-            env_variables << "ENV no_proxy #{config[:no_proxy]}\n"
-            env_variables << "ENV NO_PROXY #{config[:no_proxy]}\n"
+            env_variables << "ENV no_proxy=#{config[:no_proxy]}\n"
+            env_variables << "ENV NO_PROXY=#{config[:no_proxy]}\n"
           end
 
           env_variables

--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -68,8 +68,8 @@ module Kitchen
                 && ln -sf /bin/true /sbin/initctl
           CODE
           packages = <<-CODE
-            ENV DEBIAN_FRONTEND noninteractive
-            ENV container docker
+            ENV DEBIAN_FRONTEND=noninteractive
+            ENV container=docker
             RUN apt-get update
             RUN apt-get install -y sudo openssh-server curl lsb-release
           CODE
@@ -78,7 +78,7 @@ module Kitchen
 
         def fedora_platform
           <<-CODE
-            ENV container docker
+            ENV container=docker
             RUN dnf clean all
             RUN dnf install -y sudo openssh-server openssh-clients which curl
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
@@ -106,7 +106,7 @@ module Kitchen
 
         def opensuse_platform
           <<-CODE
-            ENV container docker
+            ENV container=docker
             RUN zypper install -y sudo openssh which curl gawk
             RUN /usr/sbin/sshd-gen-keys-start
           CODE
@@ -114,7 +114,7 @@ module Kitchen
 
         def rhel_platform
           <<-CODE
-            ENV container docker
+            ENV container=docker
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients which curl
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
@@ -124,7 +124,7 @@ module Kitchen
 
         def centosstream_platform
           <<-CODE
-            ENV container docker
+            ENV container=docker
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients which
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
@@ -134,7 +134,7 @@ module Kitchen
 
         def almalinux_platform
           <<-CODE
-            ENV container docker
+            ENV container=docker
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients which
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
@@ -144,7 +144,7 @@ module Kitchen
 
         def rockylinux_platform
           <<-CODE
-            ENV container docker
+            ENV container=docker
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients which
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
@@ -154,7 +154,7 @@ module Kitchen
 
         def photonos_platform
           <<-CODE
-            ENV container docker
+            ENV container=docker
             RUN tdnf clean all
             RUN tdnf install -y sudo openssh-server openssh-clients which curl
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N ''


### PR DESCRIPTION
Current versions of Docker Desktop will output a LegacyKeyValueFormat warning when using 'ENV key value' syntax. We switch to the updated 'ENV key=value' syntax.